### PR TITLE
Fix java home path inside container

### DIFF
--- a/.devcontainer/settings.vscode.json
+++ b/.devcontainer/settings.vscode.json
@@ -1,3 +1,3 @@
 {
-    "java.home": "/docker-java-home"
+    "java.home": "/usr/local/openjdk-8"
 }


### PR DESCRIPTION
With the original setting, the VSCode Java extension complains that the java.home is not correctly set. As a consequence, no build, run or debug is possible out of the box.