### PR TITLE
set jdk 8 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <properties>
+    <jdk.version>1.8</jdk.version>
+  </properties>
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
This fixes warnings in VS Code.
Explanation: there is an inconsistency because Maven defaults to jdk 5, while .devcontainers/Dockerfile is based on jdk8.