### PR TITLE
Fix "java.home" for VS online

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"java.home": "/usr/lib/jvm/zulu-8-azure-amd64"
+		"java.home":"/usr/lib/jvm/default-java"
 	},
 
 	// Use 'appPort' to create a container with published ports. If the port isn't working, be sure


### PR DESCRIPTION
At the moment VS online doesn't support Dockerfiles. The default image does however have Java installed.

If we change `java.home` to point at `/usr/lib/jvm/default-java` instead of `/usr/lib/jvm/zulu-8-azure-amd64`, this example will work with VS online which doesn't use the `Dockerfile`.