### PR TITLE
Remove Non Required Package from Dockerfile.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,8 +32,6 @@ RUN apt-get update \
         iproute2 \
         procps \
         curl \
-        apt-transport-https \
-        gnupg2 \
         lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.


### PR DESCRIPTION
I guess these two packages( `apt-transport-https`  and  ` gnupg2 `  )  are to use when users add a external apt repositories in `Dockerfile` . Codes could run without these packages.
So these packages are non required for the example purpose.