### PR TITLE
Update to JDK 11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM openjdk:11-jdk
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"java.home": "/usr/local/openjdk-8"
+		"java.home": "/usr/local/openjdk-11"
 	},
 	
 	// Add the IDs of extensions you want installed when the container is created.

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
     </dependency>
   </dependencies>
   <properties>
-    <jdk.version>1.8</jdk.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <jdk.version>11</jdk.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
The latest Java Extensions require at least JDK 11, this pull request updates to the JDK 11 version