### PR TITLE
Fix file encoding in Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <jdk.version>11</jdk.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
This fixes the default file encoding, and will remove this warning message when building:
```
 File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
```