### PR TITLE
Fix the URL of the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>my-app</name>
-  <url>http://maven.apache.org</url>
+  <url>https://github.com/microsoft/vscode-remote-try-java</url>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Another option would be to remove it, but anyway you shouldn't point to Maven's URL here, and in HTTP.